### PR TITLE
Fix Selector to find ALB during DNS CNAME Invocation

### DIFF
--- a/app_platform/terraform_modules/fastapi_service/main.tf
+++ b/app_platform/terraform_modules/fastapi_service/main.tf
@@ -68,7 +68,7 @@ data "aws_route53_zone" "my_domain" {
 data "aws_lb" "app_alb" {
   tags = {
     "elbv2.k8s.aws/cluster" = var.k8s_cluster_name
-    "ingress.k8s.aws/stack" = "${var.deployment_mode}/${var.project_slug}"
+    "ingress.k8s.aws/stack" = "${var.deployment_mode}-${var.chart_name}/${var.project_slug}"
   }
   depends_on = [aws_ecr_repository.app_repository]
 }

--- a/app_platform/terraform_modules/fastapi_service/variables.tf
+++ b/app_platform/terraform_modules/fastapi_service/variables.tf
@@ -22,3 +22,9 @@ variable "k8s_cluster_name" {
   description = "The name of the Kubernetes cluster."
   type        = string
 }
+
+variable "chart_name" {
+  description = "The name of the Helm chart."
+  type        = string
+  default     = "fastapi-service"
+}


### PR DESCRIPTION
Chart Name is used in the ALB Created by the Load Balancer Controller via the Helm Chart. Example below.
<img width="1288" height="181" alt="Screenshot 2025-09-01 at 5 40 48 PM" src="https://github.com/user-attachments/assets/3206252b-e970-46bd-bd99-6b9054287f88" />

We've added a TF variable with a default to work around this incompatibility. 